### PR TITLE
Drop Python 2.6 from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
- - "2.6"
  - "2.7"
  - "3.3"
  - "3.4"


### PR DESCRIPTION
Python 2.6 has been deprecated