### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 version: ~> 1.0
+os: linux
 dist: xenial   # required for Python >= 3.7
 language: python
 python:


### PR DESCRIPTION
This is the default anyway, but we get a "root: missing os, using the default linux" message from build config validation