### PR TITLE
Split Travis config into jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ jobs:
         script: pylint primes.py binary_search.py
       - &unit-tests
         script: python test.py
-      - <<: *unit-tests
         name: "Unit Tests 3.6"
         python: "3.6"
       - <<: *unit-tests
@@ -31,7 +30,6 @@ jobs:
       - &speed-test-all
         python: "3.6"
         script: python speed_test.py --all
-      - <<: *speed-test-all
         name: "Speed Test All 3.6"
         python: "3.6"
       - <<: *speed-test-all
@@ -46,7 +44,6 @@ jobs:
       - &speed-test-fermat
         python: "3.6"
         script: python speed_test.py --fermat 6
-      - <<: *speed-test-fermat
         name: "Speed Test 6 Fermat Numbers 3.6"
         python: "3.6"
       - <<: *speed-test-fermat

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,40 +12,49 @@ jobs:
         install: pip install pylint
         script: pylint primes.py binary_search.py
       - &unit-tests
-        name: "Unit Tests"
         script: python test.py
       - <<: *unit-tests
+        name: "Unit Tests 3.6"
         python: "3.6"
       - <<: *unit-tests
+        name: "Unit Tests 3.7"
         python: "3.7"
       - <<: *unit-tests
+        name: "Unit Tests 3.8"
         python: "3.8"
       - <<: *unit-tests
+        name: "Unit Tests Nightly"
         python: "nightly"
       - name: "Coverage"
         install: pip install coverage
         script: coverage run --include=primes.py,test.py,binary_search.py test.py && coverage report -m --fail-under=100 --rcfile=coveragerc
       - &speed-test-all
-        name: "Speed Test All"
         python: "3.6"
         script: python speed_test.py --all
       - <<: *speed-test-all
+        name: "Speed Test All 3.6"
         python: "3.6"
       - <<: *speed-test-all
+        name: "Speed Test All 3.7"
         python: "3.7"
       - <<: *speed-test-all
+        name: "Speed Test All 3.8"
         python: "3.8"
       - <<: *speed-test-all
+        name: "Speed Test All Nightly"
         python: "nightly"
       - &speed-test-fermat
-        name: "Speed Test 6 Fermat Numbers"
         python: "3.6"
         script: python speed_test.py --fermat 6
       - <<: *speed-test-fermat
+        name: "Speed Test 6 Fermat Numbers 3.6"
         python: "3.6"
       - <<: *speed-test-fermat
+        name: "Speed Test 6 Fermat Numbers 3.7"
         python: "3.7"
       - <<: *speed-test-fermat
+        name: "Speed Test 6 Fermat Numbers 3.8"
         python: "3.8"
       - <<: *speed-test-fermat
+        name: "Speed Test 6 Fermat Numbers Nightly"
         python: "nightly"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,20 +2,15 @@ version: ~> 1.0
 os: linux
 dist: xenial   # required for Python >= 3.7
 language: python
+python: "nightly"
 jobs:
   include:
-      - &mypy
-        name: "mypy"
+      - name: "mypy"
         install: pip install mypy
         script: mypy primes.py binary_search.py --strict
-      - <<: *mypy
-        python: "nightly"
-      - &pylint
-        name: "pylint"
+      - name: "pylint"
         install: pip install pylint
         script: pylint primes.py binary_search.py
-      - <<: *pylint
-        python: "nightly"
       - &unit-tests
         name: "Unit Tests"
         script: python test.py
@@ -27,12 +22,9 @@ jobs:
         python: "3.8"
       - <<: *unit-tests
         python: "nightly"
-      - &coverage
-        name: "Coverage"
+      - name: "Coverage"
         install: pip install coverage
         script: coverage run --include=primes.py,test.py,binary_search.py test.py && coverage report -m --fail-under=100 --rcfile=coveragerc
-      - <<: *coverage
-        python: "nightly"
       - &speed-test-all
         name: "Speed Test All"
         python: "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,13 @@ python:
  - "nightly"
 jobs:
   include:
+      - python: "3.6"
+      - python: "3.7"
+      - python: "3.8"
+      - python: "nightly"
       - name: "mypy"
         install: pip install mypy
         script: mypy primes.py binary_search.py --strict
-        python:
-          - "3.6"
-          - "3.7"
-          - "3.8"
-          - "nightly"
       - name: "pylint"
         install: pip install pylint
         script: pylint primes.py binary_search.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,20 @@ python:
  - "3.7"
  - "3.8"
  - "nightly"
-install:
- - pip install mypy
- - pip install coverage
- - pip install pylint
-script:
- - mypy primes.py binary_search.py --strict
- - python test.py
- - coverage run --include=primes.py,test.py,binary_search.py test.py && coverage report -m --fail-under=100 --rcfile=coveragerc
- - python speed_test.py --all
- - python speed_test.py --fermat 6
- - pylint primes.py binary_search.py
+jobs:
+  include:
+      - name: "mypy"
+        install: pip install mypy
+        script: mypy primes.py binary_search.py --strict
+      - name: "pylint"
+        install: pip install pylint
+        script: pylint primes.py binary_search.py
+      - name: "Unit Tests"
+        script: python test.py
+      - name: "Coverage"
+        install: pip install coverage
+        script: coverage run --include=primes.py,test.py,binary_search.py test.py && coverage report -m --fail-under=100 --rcfile=coveragerc
+      - name: "Speed Test All"
+        script: python speed_test.py --all
+      - name: "Speed Test 6 Fermat Numbers"
+        script: python speed_test.py --fermat 6

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,22 +9,87 @@ python:
  - "nightly"
 jobs:
   include:
-      - python: "3.6"
-      - python: "3.7"
-      - python: "3.8"
-      - python: "nightly"
       - name: "mypy"
+        python: "3.6"
         install: pip install mypy
         script: mypy primes.py binary_search.py --strict
       - name: "pylint"
+        python: "3.6"
         install: pip install pylint
         script: pylint primes.py binary_search.py
       - name: "Unit Tests"
+        python: "3.6"
         script: python test.py
       - name: "Coverage"
+        python: "3.6"
         install: pip install coverage
         script: coverage run --include=primes.py,test.py,binary_search.py test.py && coverage report -m --fail-under=100 --rcfile=coveragerc
       - name: "Speed Test All"
+        python: "3.6"
         script: python speed_test.py --all
       - name: "Speed Test 6 Fermat Numbers"
+        python: "3.6"
+        script: python speed_test.py --fermat 6
+      - name: "mypy"
+        python: "3.7"
+        install: pip install mypy
+        script: mypy primes.py binary_search.py --strict
+      - name: "pylint"
+        python: "3.7"
+        install: pip install pylint
+        script: pylint primes.py binary_search.py
+      - name: "Unit Tests"
+        python: "3.7"
+        script: python test.py
+      - name: "Coverage"
+        python: "3.7"
+        install: pip install coverage
+        script: coverage run --include=primes.py,test.py,binary_search.py test.py && coverage report -m --fail-under=100 --rcfile=coveragerc
+      - name: "Speed Test All"
+        python: "3.7"
+        script: python speed_test.py --all
+      - name: "Speed Test 6 Fermat Numbers"
+        python: "3.7"
+        script: python speed_test.py --fermat 6
+      - name: "mypy"
+        python: "3.8"
+        install: pip install mypy
+        script: mypy primes.py binary_search.py --strict
+      - name: "pylint"
+        python: "3.8"
+        install: pip install pylint
+        script: pylint primes.py binary_search.py
+      - name: "Unit Tests"
+        python: "3.8"
+        script: python test.py
+      - name: "Coverage"
+        python: "3.8"
+        install: pip install coverage
+        script: coverage run --include=primes.py,test.py,binary_search.py test.py && coverage report -m --fail-under=100 --rcfile=coveragerc
+      - name: "Speed Test All"
+        python: "3.8"
+        script: python speed_test.py --all
+      - name: "Speed Test 6 Fermat Numbers"
+        python: "3.8"
+        script: python speed_test.py --fermat 6
+      - name: "mypy"
+        python: "nightly"
+        install: pip install mypy
+        script: mypy primes.py binary_search.py --strict
+      - name: "pylint"
+        python: "nightly"
+        install: pip install pylint
+        script: pylint primes.py binary_search.py
+      - name: "Unit Tests"
+        python: "nightly"
+        script: python test.py
+      - name: "Coverage"
+        python: "nightly"
+        install: pip install coverage
+        script: coverage run --include=primes.py,test.py,binary_search.py test.py && coverage report -m --fail-under=100 --rcfile=coveragerc
+      - name: "Speed Test All"
+        python: "nightly"
+        script: python speed_test.py --all
+      - name: "Speed Test 6 Fermat Numbers"
+        python: "nightly"
         script: python speed_test.py --fermat 6

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,87 +4,74 @@ dist: xenial   # required for Python >= 3.7
 language: python
 jobs:
   include:
-      - name: "mypy"
-        python: "3.6"
+      - &mypy
+        name: "mypy"
         install: pip install mypy
         script: mypy primes.py binary_search.py --strict
-      - name: "pylint"
+      - <<: *mypy
         python: "3.6"
+      - <<: *mypy
+        python: "3.7"
+      - <<: *mypy
+        python: "3.8"
+      - <<: *mypy
+        python: "nightly"
+      - &pylint
+        name: "pylint"
         install: pip install pylint
         script: pylint primes.py binary_search.py
-      - name: "Unit Tests"
+      - <<: *pylint
         python: "3.6"
+      - <<: *pylint
+        python: "3.7"
+      - <<: *pylint
+        python: "3.8"
+      - <<: *pylint
+        python: "nightly"
+      - &unit-tests
+        name: "Unit Tests"
         script: python test.py
-      - name: "Coverage"
+      - <<: *unit-tests
         python: "3.6"
+      - <<: *unit-tests
+        python: "3.7"
+      - <<: *unit-tests
+        python: "3.8"
+      - <<: *unit-tests
+        python: "nightly"
+      - &coverage
+        name: "Coverage"
         install: pip install coverage
         script: coverage run --include=primes.py,test.py,binary_search.py test.py && coverage report -m --fail-under=100 --rcfile=coveragerc
-      - name: "Speed Test All"
+      - <<: *coverage
+        python: "3.6"
+      - <<: *coverage
+        python: "3.7"
+      - <<: *coverage
+        python: "3.8"
+      - <<: *coverage
+        python: "nightly"
+      - &speed-test-all
+        name: "Speed Test All"
         python: "3.6"
         script: python speed_test.py --all
-      - name: "Speed Test 6 Fermat Numbers"
+      - <<: *speed-test-all
+        python: "3.6"
+      - <<: *speed-test-all
+        python: "3.7"
+      - <<: *speed-test-all
+        python: "3.8"
+      - <<: *speed-test-all
+        python: "nightly"
+      - &speed-test-fermat
+        name: "Speed Test 6 Fermat Numbers"
         python: "3.6"
         script: python speed_test.py --fermat 6
-      - name: "mypy"
+      - <<: *speed-test-fermat
+        python: "3.6"
+      - <<: *speed-test-fermat
         python: "3.7"
-        install: pip install mypy
-        script: mypy primes.py binary_search.py --strict
-      - name: "pylint"
-        python: "3.7"
-        install: pip install pylint
-        script: pylint primes.py binary_search.py
-      - name: "Unit Tests"
-        python: "3.7"
-        script: python test.py
-      - name: "Coverage"
-        python: "3.7"
-        install: pip install coverage
-        script: coverage run --include=primes.py,test.py,binary_search.py test.py && coverage report -m --fail-under=100 --rcfile=coveragerc
-      - name: "Speed Test All"
-        python: "3.7"
-        script: python speed_test.py --all
-      - name: "Speed Test 6 Fermat Numbers"
-        python: "3.7"
-        script: python speed_test.py --fermat 6
-      - name: "mypy"
+      - <<: *speed-test-fermat
         python: "3.8"
-        install: pip install mypy
-        script: mypy primes.py binary_search.py --strict
-      - name: "pylint"
-        python: "3.8"
-        install: pip install pylint
-        script: pylint primes.py binary_search.py
-      - name: "Unit Tests"
-        python: "3.8"
-        script: python test.py
-      - name: "Coverage"
-        python: "3.8"
-        install: pip install coverage
-        script: coverage run --include=primes.py,test.py,binary_search.py test.py && coverage report -m --fail-under=100 --rcfile=coveragerc
-      - name: "Speed Test All"
-        python: "3.8"
-        script: python speed_test.py --all
-      - name: "Speed Test 6 Fermat Numbers"
-        python: "3.8"
-        script: python speed_test.py --fermat 6
-      - name: "mypy"
+      - <<: *speed-test-fermat
         python: "nightly"
-        install: pip install mypy
-        script: mypy primes.py binary_search.py --strict
-      - name: "pylint"
-        python: "nightly"
-        install: pip install pylint
-        script: pylint primes.py binary_search.py
-      - name: "Unit Tests"
-        python: "nightly"
-        script: python test.py
-      - name: "Coverage"
-        python: "nightly"
-        install: pip install coverage
-        script: coverage run --include=primes.py,test.py,binary_search.py test.py && coverage report -m --fail-under=100 --rcfile=coveragerc
-      - name: "Speed Test All"
-        python: "nightly"
-        script: python speed_test.py --all
-      - name: "Speed Test 6 Fermat Numbers"
-        python: "nightly"
-        script: python speed_test.py --fermat 6

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,23 +9,11 @@ jobs:
         install: pip install mypy
         script: mypy primes.py binary_search.py --strict
       - <<: *mypy
-        python: "3.6"
-      - <<: *mypy
-        python: "3.7"
-      - <<: *mypy
-        python: "3.8"
-      - <<: *mypy
         python: "nightly"
       - &pylint
         name: "pylint"
         install: pip install pylint
         script: pylint primes.py binary_search.py
-      - <<: *pylint
-        python: "3.6"
-      - <<: *pylint
-        python: "3.7"
-      - <<: *pylint
-        python: "3.8"
       - <<: *pylint
         python: "nightly"
       - &unit-tests
@@ -43,12 +31,6 @@ jobs:
         name: "Coverage"
         install: pip install coverage
         script: coverage run --include=primes.py,test.py,binary_search.py test.py && coverage report -m --fail-under=100 --rcfile=coveragerc
-      - <<: *coverage
-        python: "3.6"
-      - <<: *coverage
-        python: "3.7"
-      - <<: *coverage
-        python: "3.8"
       - <<: *coverage
         python: "nightly"
       - &speed-test-all

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,31 +27,18 @@ jobs:
       - name: "Coverage"
         install: pip install coverage
         script: coverage run --include=primes.py,test.py,binary_search.py test.py && coverage report -m --fail-under=100 --rcfile=coveragerc
-      - &speed-test-all
+      - &speed-test
+        script: 
+          - python speed_test.py --all
+          - python speed_test.py --fermat 6
+        name: "Speed Test 3.6"
         python: "3.6"
-        script: python speed_test.py --all
-        name: "Speed Test All 3.6"
-        python: "3.6"
-      - <<: *speed-test-all
-        name: "Speed Test All 3.7"
+      - <<: *speed-test
+        name: "Speed Test 3.7"
         python: "3.7"
-      - <<: *speed-test-all
-        name: "Speed Test All 3.8"
+      - <<: *speed-test
+        name: "Speed Test 3.8"
         python: "3.8"
-      - <<: *speed-test-all
-        name: "Speed Test All Nightly"
-        python: "nightly"
-      - &speed-test-fermat
-        python: "3.6"
-        script: python speed_test.py --fermat 6
-        name: "Speed Test 6 Fermat Numbers 3.6"
-        python: "3.6"
-      - <<: *speed-test-fermat
-        name: "Speed Test 6 Fermat Numbers 3.7"
-        python: "3.7"
-      - <<: *speed-test-fermat
-        name: "Speed Test 6 Fermat Numbers 3.8"
-        python: "3.8"
-      - <<: *speed-test-fermat
-        name: "Speed Test 6 Fermat Numbers Nightly"
+      - <<: *speed-test
+        name: "Speed Test Nightly"
         python: "nightly"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,11 @@ jobs:
       - name: "mypy"
         install: pip install mypy
         script: mypy primes.py binary_search.py --strict
+        python:
+          - "3.6"
+          - "3.7"
+          - "3.8"
+          - "nightly"
       - name: "pylint"
         install: pip install pylint
         script: pylint primes.py binary_search.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,6 @@ version: ~> 1.0
 os: linux
 dist: xenial   # required for Python >= 3.7
 language: python
-python:
- - "3.6"
- - "3.7"
- - "3.8"
- - "nightly"
 jobs:
   include:
       - name: "mypy"


### PR DESCRIPTION
This should allow the CI to run faster by avoiding redundant stages across Python versions (no reason to run mypy, pylint, or coverage under each Python version, so just run once under nightly) and allow better parallelisation (e.g. running coverage in parallel with unit tests).

In practice it'll require fine tuning as each job has the overhead of setting up the environment (30+ seconds).

It's also quite fiddly as the jobs matrix isn't expanded over top-level python versions, so we have to do it manually with YAML aliases.