### PR TITLE
Allow failures for Python nightly on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ python:
  - "3.7"
  - "3.8"
  - "nightly"
+jobs:
+ allow_failures:
+  - python: nightly
 install:
  - pip install mypy
  - pip install coverage


### PR DESCRIPTION
There is a CPython problem causing it to [fail currently](https://travis-ci.org/github/liam-m/primes.py/jobs/733795303) - see [pypa/wheel#354](https://github.com/pypa/wheel/issues/354) and [python/cpython#20333](https://github.com/python/cpython/pull/20333). 

This can be reverted once it's resolved.